### PR TITLE
Fix build by removing external font fetches

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,15 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata = {
   title: "Create Next App",
@@ -19,9 +8,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- remove `next/font` usage that fetches fonts from blocked domains
- drop unused font-related CSS variables

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687dee09a1e483269628f7a3cb1bb8db